### PR TITLE
Fix Twitter link in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ header_pages:
  - blog.md
  - contact.md
 
-footer: 'made with peace in mind, by <a href="twitter.com/aleesteele">@aleesteele</a>'
+footer: 'made with peace in mind, by <a href="https://twitter.com/aleesteele">@aleesteele</a>'
 
 style: light # dark (default) or light
 #listen_for_clients_preferred_style: true # true or false (default)


### PR DESCRIPTION
The link doesn't start on a scheme.
Browsers read it as a relative link to https://www.aleesteele.com/twitter.com/aleesteele